### PR TITLE
[VEGA-3237] ci: add common ci build

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi7/nodejs-12
+
+WORKDIR /app
+
+RUN npm install --global yarn
+
+USER root

--- a/ci/build-entrypoint.sh
+++ b/ci/build-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ -z "$NPM_URI" ]
+then
+  NPM_URI="npm.pkg.github.com"
+fi
+
+if [ -z "$NPM_AUTH_TOKEN" ]
+then
+  echo "NPM_AUTH_TOKEN is required to continue. Abort."
+  exit 1;
+fi
+
+NPMRC_TEMP=$(cat .npmrc)
+
+sed -e "s/\$NPM_URI/$NPM_URI/" \
+    -e "s/\$NPM_AUTH_TOKEN/$NPM_AUTH_TOKEN/" ./ci/npmrc-template > .npmrc
+
+yarn install --frozen-lockfile
+yarn build
+
+echo -e "$NPMRC_TEMP" > .npmrc

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ -z "$VEGA_REPOPREFIX" ]
+then
+  VEGA_REPOPREFIX="vega-fem"
+fi
+
+if [ -z "$IMAGE_NAME" ]
+then
+  IMAGE_NAME="frontend-builder"
+fi
+
+if [ -z "$FE_BUILDER_VERSION" ]
+then
+  FE_BUILDER_VERSION="1"
+fi
+
+TAG="$VEGA_REPOPREFIX/$IMAGE_NAME:$FE_BUILDER_VERSION"
+NAME="$VEGA_REPOPREFIX.$IMAGE_NAME"
+
+if [[ -z "$REBUILD" ]];
+then
+  echo "Docker image build."
+  docker build -t $TAG ./ci
+else
+  echo "Docker image force rebuild."
+  docker build -t $TAG --no-cache ./ci
+fi
+
+docker rm $NAME
+
+docker run \
+  --name "$NAME" \
+  -v "$(pwd):/app" \
+  --env NPM_URI=$NPM_URI \
+  --env NPM_AUTH_TOKEN=$NPM_AUTH_TOKEN \
+  --env BASE_API_URL=$BASE_API_URL \
+  $TAG \
+  /app/ci/build-entrypoint.sh

--- a/ci/npmrc-template
+++ b/ci/npmrc-template
@@ -1,0 +1,3 @@
+@gpn-prototypes:registry=https://$NPM_URI
+//$NPM_URI/:_authToken=$NPM_AUTH_TOKEN
+


### PR DESCRIPTION
## Задача
Задача в Jira: https://jira.konakov.tv/browse/VEGA-3237
Ссылка на стенд: https://VEGA-3237.vega-fem.csssr.cloud
ref: VEGA-3237

### Description

Добавлены sh скрипты общей сборки и образ сборщика 

### Checks

- [x] Jira link attached: [VEGA-3237]()
- [ ] Possible Associated Jira links:
- [ ] Personal Vega Instance link attached: http://xx-yy-vega-builder.code013.org
- [ ] Jira tasks for technical debt were created (if needed)

### Type

- [ ] Feature
- [ ] Alpha Feature ([Alpha] MR/PR Title)
- [ ] Bug Fix
- [ ] Test
- [ ] Refactoring

### PR/MR Requirements

- [x] PR/MR title meet requirements/convention
- [ ] Target branch is correct
- [ ] PR/MR branch was rebased at correct branch
- [ ] Diff was checked
- [ ] Configuration files were checked at test repositories
- [ ] [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)

### General

- [ ] Exploratory Tested at Personal Vega Instance
- [ ] Existing E2E Tests done, Screenshot attached
- [ ] Existing Integration Tests done, Screenshot attached, Jenkins link:
- [ ] Existing Unit Tests done, Screenshot attached
- [ ] New E2E Tests developed
- [ ] New Integration Tests developed
- [ ] New Unit Tests developed
- [ ] API documentation was fully and correctly updated

### E2E Suite Jenkins link

_{link}_

### E2E Suite Screenshot

_{Screenshot}_

### Integration Tests Screenshot

_{Screenshot}_

### Unit Tests Screenshot

_{Screenshot}_
